### PR TITLE
feat: containerize apps and add release workflow for ghcr.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '**/v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Parse app name and version from tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^[a-z0-9-]+/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: $TAG (expected <app>/vX.Y.Z)" && exit 1
+          fi
+          APP="${TAG%%/v*}"
+          VERSION="${TAG#*/}"
+          echo "app=${APP}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/${{ steps.parse.outputs.app }}/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/lewis-wow/virtual-webauthn-authenticator/${{ steps.parse.outputs.app }}:${{ steps.parse.outputs.version }}
+            ghcr.io/lewis-wow/virtual-webauthn-authenticator/${{ steps.parse.outputs.app }}:latest

--- a/apps/api-bff/Dockerfile
+++ b/apps/api-bff/Dockerfile
@@ -22,7 +22,7 @@ RUN corepack enable pnpm
 FROM base AS pruner
 RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/hono --docker
+RUN turbo prune @repo/api-bff --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace
@@ -33,7 +33,7 @@ COPY --from=pruner /app/out/full .
 COPY --from=pruner /app/out/json/pnpm-lock.yaml .
 COPY --from=pruner /app/scripts ./scripts
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod=false --fetch-retries=5 --fetch-timeout=120000
+RUN --mount=type=cache,id=pnpm-api-bff,target=/pnpm/store pnpm install --frozen-lockfile --prod=false --fetch-retries=5 --fetch-timeout=120000
 
 RUN pnpx turbo run build
 
@@ -45,23 +45,19 @@ FROM base AS production
 RUN pnpm add -g @dotenvx/dotenvx
 WORKDIR /app
 
-ENV PRISMA_QUERY_ENGINE_LIBRARY="/app/packages/prisma/src/generated/client/libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node"
-
 COPY --from=pruner /app/out/full .
 COPY --from=pruner /app/out/json/pnpm-lock.yaml .
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --fetch-retries=5 --fetch-timeout=120000
+RUN --mount=type=cache,id=pnpm-api-bff,target=/pnpm/store pnpm install --prod --fetch-retries=5 --fetch-timeout=120000
 
-COPY --from=builder /app/apps/hono/dist ./apps/hono/dist
-COPY apps/hono/static ./apps/hono/static
-COPY apps/hono/.env.production ./apps/hono/.env.production
+COPY --from=builder /app/apps/api-bff/dist ./apps/api-bff/dist
+COPY apps/api-bff/.env.production ./apps/api-bff/.env.production
 
 RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 hono
-RUN chown -R hono:nodejs /app
-USER hono
+    && adduser --system --uid 1001 apibff
+RUN chown -R apibff:nodejs /app
+USER apibff
 
 EXPOSE 3001
 
-CMD ["dotenvx", "run",  "-f", "apps/hono/.env.production", "--", "node", "apps/hono/dist/index.js"]
-
+CMD ["dotenvx", "run", "-f", "apps/api-bff/.env.production", "--", "node", "apps/api-bff/dist/index.js"]

--- a/apps/api-bff/Dockerfile
+++ b/apps/api-bff/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
 ENV CI=1
 
 RUN corepack enable pnpm
@@ -20,9 +20,8 @@ RUN corepack enable pnpm
 # STAGE 2: Prune the monorepo
 # =========================================================================== #
 FROM base AS pruner
-RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/api-bff --docker
+RUN pnpx turbo prune @repo/api-bff --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
 ENV CI=1
 
 RUN corepack enable pnpm
@@ -20,9 +20,8 @@ RUN corepack enable pnpm
 # STAGE 2: Prune the monorepo
 # =========================================================================== #
 FROM base AS pruner
-RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/auth-server --docker
+RUN pnpx turbo prune @repo/auth-server --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace

--- a/apps/auth-server/Dockerfile
+++ b/apps/auth-server/Dockerfile
@@ -22,7 +22,7 @@ RUN corepack enable pnpm
 FROM base AS pruner
 RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/hono --docker
+RUN turbo prune @repo/auth-server --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace
@@ -33,7 +33,7 @@ COPY --from=pruner /app/out/full .
 COPY --from=pruner /app/out/json/pnpm-lock.yaml .
 COPY --from=pruner /app/scripts ./scripts
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod=false --fetch-retries=5 --fetch-timeout=120000
+RUN --mount=type=cache,id=pnpm-auth-server,target=/pnpm/store pnpm install --frozen-lockfile --prod=false --fetch-retries=5 --fetch-timeout=120000
 
 RUN pnpx turbo run build
 
@@ -45,23 +45,19 @@ FROM base AS production
 RUN pnpm add -g @dotenvx/dotenvx
 WORKDIR /app
 
-ENV PRISMA_QUERY_ENGINE_LIBRARY="/app/packages/prisma/src/generated/client/libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node"
-
 COPY --from=pruner /app/out/full .
 COPY --from=pruner /app/out/json/pnpm-lock.yaml .
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --fetch-retries=5 --fetch-timeout=120000
+RUN --mount=type=cache,id=pnpm-auth-server,target=/pnpm/store pnpm install --prod --fetch-retries=5 --fetch-timeout=120000
 
-COPY --from=builder /app/apps/hono/dist ./apps/hono/dist
-COPY apps/hono/static ./apps/hono/static
-COPY apps/hono/.env.production ./apps/hono/.env.production
+COPY --from=builder /app/apps/auth-server/dist ./apps/auth-server/dist
+COPY apps/auth-server/.env.production ./apps/auth-server/.env.production
 
 RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 hono
-RUN chown -R hono:nodejs /app
-USER hono
+    && adduser --system --uid 1001 authserver
+RUN chown -R authserver:nodejs /app
+USER authserver
 
 EXPOSE 3001
 
-CMD ["dotenvx", "run",  "-f", "apps/hono/.env.production", "--", "node", "apps/hono/dist/index.js"]
-
+CMD ["dotenvx", "run", "-f", "apps/auth-server/.env.production", "--", "node", "apps/auth-server/dist/index.js"]

--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
 ENV CI=1
 RUN corepack enable pnpm
 
@@ -16,9 +16,8 @@ RUN corepack enable pnpm
 # STAGE 2: Prune the monorepo for the Next.js app
 # =========================================================================== #
 FROM base AS pruner
-RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/console --docker
+RUN pnpx turbo prune @repo/console --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace

--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -42,8 +42,6 @@ FROM base AS production
 RUN pnpm add -g @dotenvx/dotenvx
 WORKDIR /app
 
-ENV PRISMA_QUERY_ENGINE_LIBRARY="/app/packages/prisma/src/generated/client/libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node"
-
 # 1. Copy dependency-related files from the pruner stage
 COPY --from=pruner /app/out/json/pnpm-lock.yaml .
 COPY --from=pruner /app/out/json/pnpm-workspace.yaml .

--- a/apps/nestjs/Dockerfile
+++ b/apps/nestjs/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 ENV TURBO_TELEMETRY_DISABLED=1
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
 ENV CI=1
 RUN corepack enable pnpm
 
@@ -16,9 +16,8 @@ RUN corepack enable pnpm
 # STAGE 2: Prune the monorepo for the Next.js app
 # =========================================================================== #
 FROM base AS pruner
-RUN pnpm install --global turbo
 COPY . .
-RUN turbo prune @repo/nestjs --docker
+RUN pnpx turbo prune @repo/nestjs --docker
 
 # =========================================================================== #
 # STAGE 3: Build the application using the pruned workspace

--- a/apps/nestjs/Dockerfile
+++ b/apps/nestjs/Dockerfile
@@ -42,7 +42,6 @@ FROM base AS production
 RUN pnpm add -g @dotenvx/dotenvx
 WORKDIR /app
 
-ENV PRISMA_QUERY_ENGINE_LIBRARY="/app/packages/prisma/src/generated/client/libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node"
 ENV ENVIRONMENT="production"
 
 # 1. Copy dependency-related files from the pruner stage


### PR DESCRIPTION
Fix api-bff and auth-server Dockerfiles which were referencing the non-existent @repo/hono package. Remove the hardcoded ARM64 Prisma engine path from all four Dockerfiles so builds work on linux/amd64.

Add .github/workflows/release.yml that triggers on per-app tags (<app>/vX.Y.Z), builds only the tagged app's image, and pushes versioned + latest tags to ghcr.io.