### PR TITLE
chore(release): version bump

### DIFF
--- a/apps/api-bff/CHANGELOG.md
+++ b/apps/api-bff/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.1.0 (2026-07-28)
+
+### 🚀 Features
+
+- containerize apps and add release workflow for ghcr.io publishing ([#174](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/174))
+- store user display name ([#166](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/166))
+- state token ([#114](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/114))
+- **virtual-authenticator:** multiple credentials UI ([#76](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/76))
+
+### 🩹 Fixes
+
+- deps ([#191](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/191))
+
+### ❤️ Thank You
+
+- Claude Sonnet 4.6
+- Copilot
+- Ludvík Prokopec @lewis-wow
+
 # Changelog
 
 ## [1.0.2](https://github.com/lewis-wow/virtual-webauthn-authenticator/compare/api-bff/v1.0.1...api-bff/v1.0.2) (2026-07-27)

--- a/apps/api-bff/package.json
+++ b/apps/api-bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/api-bff",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS='--import tsx' pnpm dotenvx rollup -c --watch",

--- a/apps/auth-server/CHANGELOG.md
+++ b/apps/auth-server/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.1.0 (2026-07-28)
+
+### 🚀 Features
+
+- containerize apps and add release workflow for ghcr.io publishing ([#174](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/174))
+- state token ([#114](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/114))
+- **virtual-authenticator:** multiple credentials UI ([#76](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/76))
+- packed attestation ([#64](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/64))
+- plasmo extension ([#62](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/62))
+- api key integration ([#61](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/61))
+- migrate from hono ([#56](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/56))
+- better auth api keys ([#54](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/54))
+- ts-rest ([#52](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/52))
+
+### 🩹 Fixes
+
+- deps ([#191](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/191))
+- permission values ([#160](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/160))
+
+### ❤️ Thank You
+
+- Claude Sonnet 4.6
+- Ludvík Prokopec @lewis-wow
+
 # Changelog
 
 ## [1.0.2](https://github.com/lewis-wow/virtual-webauthn-authenticator/compare/auth-server/v1.0.1...auth-server/v1.0.2) (2026-07-27)

--- a/apps/auth-server/package.json
+++ b/apps/auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/auth-server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS='--import tsx' pnpm dotenvx rollup -c --watch",

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -1,3 +1,38 @@
+## 1.1.0 (2026-07-28)
+
+### 🚀 Features
+
+- containerize apps and add release workflow for ghcr.io publishing ([#174](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/174))
+- store user display name ([#166](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/166))
+- uv pin ([#118](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/118))
+- state token ([#114](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/114))
+- Virtual authenticator parser ([#75](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/75))
+- example ([#67](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/67))
+- packed attestation ([#64](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/64))
+- plasmo extension ([#62](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/62))
+- api key integration ([#61](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/61))
+- migrate from hono ([#56](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/56))
+- better auth api keys ([#54](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/54))
+- ts-rest ([#52](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/52))
+- auth server ([#50](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/50))
+- jwt ([#49](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/49))
+- auth ([#48](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/48))
+- docker ([#33](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/33))
+- prettier plugin sort imports ([#28](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/28))
+- console ([#22](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/22))
+
+### 🩹 Fixes
+
+- deps ([#191](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/191))
+- release ([#177](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/177))
+- rename endpoints ([#150](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/150))
+
+### ❤️ Thank You
+
+- Claude Sonnet 4.6
+- Copilot
+- Ludvík Prokopec @lewis-wow
+
 # Changelog
 
 ## [1.0.2](https://github.com/lewis-wow/virtual-webauthn-authenticator/compare/console/v1.0.1...console/v1.0.2) (2026-07-27)

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/console",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/nestjs/CHANGELOG.md
+++ b/apps/nestjs/CHANGELOG.md
@@ -1,3 +1,48 @@
+## 1.1.0 (2026-07-28)
+
+### 🚀 Features
+
+- containerize apps and add release workflow for ghcr.io publishing ([#174](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/174))
+- store user display name ([#166](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/166))
+- flexible user handle ([#162](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/162))
+- uv pin ([#118](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/118))
+- state token ([#114](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/114))
+- extensions ([#112](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/112))
+- **virtual-authenticator:** multiple credentials UI ([#76](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/76))
+- Virtual authenticator parser ([#75](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/75))
+- packed attestation ([#64](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/64))
+- plasmo extension ([#62](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/62))
+- api key integration ([#61](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/61))
+- **nestjs:** openapi scalar ([#59](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/59))
+- webauthn credentials API ([#58](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/58))
+- migrate from hono ([#56](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/56))
+- better auth api keys ([#54](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/54))
+- ts-rest ([#52](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/52))
+- auth server ([#50](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/50))
+- passport ([#9](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/9))
+- webpack sourcemaps ([#8](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/8))
+- prisma ([#7](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/7))
+- turbo ([#5](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/5))
+
+### 🩹 Fixes
+
+- deps ([#191](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/191))
+- nestjs ([#189](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/189))
+- release please trigger workflow ([#185](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/185))
+- remove console.log ([#183](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/183))
+- test release ([#181](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/181))
+- release ([#177](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/177))
+- permission values ([#160](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/160))
+- rename endpoints ([#150](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/150))
+- **nestjs:** vitest esm ([#55](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/55))
+- ci ([#16](https://github.com/lewis-wow/virtual-webauthn-authenticator/pull/16))
+
+### ❤️ Thank You
+
+- Claude Sonnet 4.6
+- Copilot
+- Ludvík Prokopec @lewis-wow
+
 # Changelog
 
 ## [1.0.6](https://github.com/lewis-wow/virtual-webauthn-authenticator/compare/nestjs/v1.0.5...nestjs/v1.0.6) (2026-07-27)

--- a/apps/nestjs/package.json
+++ b/apps/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/nestjs",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "type": "commonjs",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Automated version bump and changelog update from `nx release`. The release tags have already been pushed and their GitHub Releases created; merge this PR to bring the version bump onto `master`.